### PR TITLE
Feat/splits

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,9 +5,10 @@ import { AddressModule } from './address/address.module';
 import { CustomerModule } from './customer/customer.module';
 import { CardModule } from './card/card.module';
 import { ItemModule } from './item/item.module';
+import { SplitModule } from './split/split.module';
 
 @Module({
-  imports: [AddressModule, CustomerModule, CardModule, ItemModule],
+  imports: [AddressModule, CustomerModule, CardModule, ItemModule, SplitModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/src/split/dto/create-split.dto.ts
+++ b/backend/src/split/dto/create-split.dto.ts
@@ -1,0 +1,15 @@
+import { IsInt, IsNumber, Min } from 'class-validator';
+
+export class CreateSplitDto {
+  @IsInt()
+  @Min(1)
+  recipient_id: number;
+
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  amount: number;
+
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  net_amount: number;
+}

--- a/backend/src/split/entities/split.entity.ts
+++ b/backend/src/split/entities/split.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class Split {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'int' })
+  recipient_id: number;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
+  amount: number;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
+  net_amount: number;
+}

--- a/backend/src/split/split.controller.spec.ts
+++ b/backend/src/split/split.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SplitController } from './split.controller';
+import { SplitService } from './split.service';
+
+describe('SplitController', () => {
+  let controller: SplitController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SplitController],
+      providers: [SplitService],
+    }).compile();
+
+    controller = module.get<SplitController>(SplitController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/split/split.controller.ts
+++ b/backend/src/split/split.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+import { SplitService } from './split.service';
+import { CreateSplitDto } from './dto/create-split.dto';
+
+@Controller('split')
+export class SplitController {
+  constructor(private readonly splitService: SplitService) {}
+
+  @Post()
+  create(@Body() createSplitDto: CreateSplitDto) {
+    return this.splitService.create(createSplitDto);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.splitService.findOne(+id);
+  }
+}

--- a/backend/src/split/split.module.ts
+++ b/backend/src/split/split.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SplitService } from './split.service';
+import { SplitController } from './split.controller';
+
+@Module({
+  controllers: [SplitController],
+  providers: [SplitService],
+})
+export class SplitModule {}

--- a/backend/src/split/split.service.spec.ts
+++ b/backend/src/split/split.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SplitService } from './split.service';
+
+describe('SplitService', () => {
+  let service: SplitService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SplitService],
+    }).compile();
+
+    service = module.get<SplitService>(SplitService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/split/split.service.ts
+++ b/backend/src/split/split.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { CreateSplitDto } from './dto/create-split.dto';
+
+@Injectable()
+export class SplitService {
+  create(createSplitDto: CreateSplitDto) {
+    return 'This action adds a new split';
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} split`;
+  }
+}


### PR DESCRIPTION
Este pull request introduz dois novos módulos, `ItemModule` e `SplitModule`, à aplicação backend. Esses módulos incluem suas respectivas entidades, DTOs, serviços, controladores e testes unitários, integrando-os ao módulo principal da aplicação. Abaixo, um resumo das alterações mais importantes:

### Integração de Novos Módulos

* **`ItemModule` adicionado à aplicação**:
- Integração de `ItemModule` ao `AppModule`, adicionando-o ao array `imports` em `backend/src/app.module.ts`.
- Criação da entidade `Item` com os campos `id`, `external_ref`, `title`, `unit_price`, `quantity` e `tangible` em `backend/src/item/entities/item.entity.ts`.

- Definido `CreateItemDto` para validação de entrada em `backend/src/item/dto/create-item.dto.ts`.
- Implementado `ItemService` com métodos de espaço reservado para criar e recuperar itens em `backend/src/item/item.service.ts`.
- Configurado `ItemController` com endpoints para criar e recuperar itens em `backend/src/item/item.controller.ts`.
- Adicionados testes unitários para `ItemController` e `ItemService` em `backend/src/item/item.controller.spec.ts` e `backend/src/item/item.service.spec.ts`, respectivamente. [[1]](diffhunk://#diff-cddf80e4882f2a310ea5819a01e055d741fcd9515e02582d5f60f83de8a9c4b8R1-R20) [[2]](diffhunk://#diff-bdc848f3367d03730e1d44f11e9340f16ca3c636d966272e4ea4e6be3aed34deR1-R18)

* **`SplitModule` adicionado ao aplicativo**:
- `SplitModule` integrado ao `AppModule` adicionando-o ao array `imports` em `backend/src/app.module.ts`.

- Criada a entidade `Split` com os campos `id`, `recipient_id`, `amount` e `net_amount` em `backend/src/split/entities/split.entity.ts`.
- Definida a função `CreateSplitDto` para validação de entrada em `backend/src/split/dto/create-split.dto.ts`.
- Implementada a função `SplitService` com métodos de espaço reservado para criar e recuperar divisões em `backend/src/split/split.service.ts`.
- Configurada a função `SplitController` com endpoints para criar e recuperar divisões em `backend/src/split/split.controller.ts`.
- Testes unitários adicionados para `SplitController` e `SplitService` em `backend/src/split/split.controller.spec.ts` e `backend/src/split/split.service.spec.ts`, respectivamente. [[1]](diffhunk://#diff-9633b052cff1a1288b7cc79d8fc27390c511384d307a1c4be877bb7cf17c57e1R1-R20) [[2]](diffhunk://#diff-370d6c442dacea8da0816045a779fa2e18e55da7f936d4a2d0698c4f3ab64335R1-R18)